### PR TITLE
gcc and root versions

### DIFF
--- a/Env/setupEnvCPU.sh
+++ b/Env/setupEnvCPU.sh
@@ -68,10 +68,6 @@ function run_setup()
     #conda install -c conda-forge cmake --yes || return 1
     #conda install -c nlesc root-numpy=4.4.0 --yes || return 1
     #conda install -c conda-forge boost=1.64.0 --yes || return 1
-
-    echo "Installing gcc"
-    conda install -c cgat gcc --yes &>> $LOGFILE
-    
     echo "Installing pip packages"
     pip install --no-cache-dir -r $SCRIPT_DIR/packages_cpu.pip &>> $LOGFILE || return 1
     
@@ -80,7 +76,8 @@ function run_setup()
     conda install -c anaconda graphviz --yes &>> $LOGFILE || return 1
     echo "Installing root"
     conda install -c nlesc root-numpy=4.4.0 --yes &>> $LOGFILE || return 1
-    
+    conda update -f libstdcxx-ng --yes &>> $LOGFILE || return 1
+
     echo "Generate setup script"
     echo "export PATH="$INSTALL_ABSDIR"/miniconda/bin:\$PATH" > $SCRIPT_DIR/env_cpu.sh
     #echo "export LD_PRELOAD="$INSTALL_ABSDIR"/miniconda/lib/libmkl_core.so:"$INSTALL_ABSDIR"/miniconda/lib/libmkl_sequential.so:\$LD_PRELOAD" >> $SCRIPT_DIR/env_cpu.sh

--- a/Env/setupEnvCPU.sh
+++ b/Env/setupEnvCPU.sh
@@ -68,6 +68,9 @@ function run_setup()
     #conda install -c conda-forge cmake --yes || return 1
     #conda install -c nlesc root-numpy=4.4.0 --yes || return 1
     #conda install -c conda-forge boost=1.64.0 --yes || return 1
+
+    echo "Installing gcc"
+    conda install -c cgat gcc --yes &>> $LOGFILE
     
     echo "Installing pip packages"
     pip install --no-cache-dir -r $SCRIPT_DIR/packages_cpu.pip &>> $LOGFILE || return 1

--- a/Env/setupEnvFull.sh
+++ b/Env/setupEnvFull.sh
@@ -68,6 +68,8 @@ function run_setup()
     #conda install -c conda-forge cmake --yes || return 1
     #conda install -c nlesc root-numpy=4.4.0 --yes || return 1
     #conda install -c conda-forge boost=1.64.0 --yes || return 1
+    echo "Installing gcc"
+    conda install -c cgat gcc --yes &>> $LOGFILE
     
     echo "Installing pip packages"
     pip install --no-cache-dir -r $SCRIPT_DIR/packages_cpu.pip &>> $LOGFILE || return 1

--- a/Env/setupEnvFull.sh
+++ b/Env/setupEnvFull.sh
@@ -68,8 +68,6 @@ function run_setup()
     #conda install -c conda-forge cmake --yes || return 1
     #conda install -c nlesc root-numpy=4.4.0 --yes || return 1
     #conda install -c conda-forge boost=1.64.0 --yes || return 1
-    echo "Installing gcc"
-    conda install -c cgat gcc --yes &>> $LOGFILE
     
     echo "Installing pip packages"
     pip install --no-cache-dir -r $SCRIPT_DIR/packages_cpu.pip &>> $LOGFILE || return 1
@@ -79,6 +77,7 @@ function run_setup()
     conda install -c anaconda graphviz --yes &>> $LOGFILE || return 1
     echo "Installing root"
     conda install -c nlesc root-numpy=4.4.0 --yes &>> $LOGFILE || return 1
+    conda update -f libstdcxx-ng --yes &>> $LOGFILE || return 1
     
     echo "Generate setup script"
     echo "export PATH="$INSTALL_ABSDIR"/miniconda/bin:\$PATH" > $SCRIPT_DIR/env_cpu.sh


### PR DESCRIPTION
On my laptop, I get the following error when running Training.py

```
tensorflow.python.framework.errors_impl.NotFoundError: /home/vc1117/XTagger/Ops/release/lib/python2.7/site-packages/xtagger/libRootWriter.so: undefined symbol: _ZN5TTreeC1EPKcS1_iP10TDirectory
```

Something broken with the version of root installed by root-numpy? Or the compilation of Ops?

In env.log the following versions are specified as being installed:
```
 gcc:              4.8.2-25              nlesc
 root:             6.04-py2.7_gcc4.8.2   nlesc
```