### PR TITLE
temp remove RootWriter from xtagger module

### DIFF
--- a/Ops/CMakeLists.txt
+++ b/Ops/CMakeLists.txt
@@ -34,12 +34,13 @@ add_library(RootReader
 target_link_libraries(RootReader ${TensorFlow_LIBRARY} ${ROOT_LIBRARIES} -lTreePlayer)
 install(TARGETS RootReader LIBRARY DESTINATION ${SITEPACKDIR})
 
-add_library(RootWriter
-    MODULE
-    RootWriter.cc
-)
-target_link_libraries(RootWriter ${TensorFlow_LIBRARY} ${ROOT_LIBRARIES})
-install(TARGETS RootWriter LIBRARY DESTINATION ${SITEPACKDIR})
+#add_library(RootWriter
+    #MODULE
+    #RootWriter.cc
+    #)
+#target_link_libraries(RootWriter ${TensorFlow_LIBRARY} ${ROOT_LIBRARIES})
+#install(TARGETS RootWriter LIBRARY DESTINATION ${SITEPACKDIR})
+
 
 add_library(ClassificationWeights
     MODULE
@@ -66,7 +67,7 @@ install(TARGETS Resampler LIBRARY DESTINATION ${SITEPACKDIR})
 set(pythonfiles
     __init__.py
     root_reader.py
-    root_writer.py
+    #root_writer.py
     resampler.py
     fake_background.py
     classification_weights.py

--- a/Ops/__init__.py
+++ b/Ops/__init__.py
@@ -1,5 +1,5 @@
 from .root_reader import root_reader
-from .root_writer import root_writer
+#from .root_writer import root_writer
 from .resampler import resampler
 from .fake_background import fake_background
 from .classification_weights import classification_weights


### PR DESCRIPTION
Currently RootWriter is not used. Remove temporarily due to following occurring on several platforms 
`
undefined symbol: _ZN5TTreeC1EPKcS1_iP10TDirectory
`